### PR TITLE
fix lint for application

### DIFF
--- a/build/run-code-lint.sh
+++ b/build/run-code-lint.sh
@@ -22,7 +22,7 @@ gem install mdl
 gem install awesome_bot
 
 # Install golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.20.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.25.0
 
 # Start lint task
 make lint

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -49,9 +49,8 @@ var (
 	operatorMetricsPort int = 8689
 )
 
-// RunManager starts the actual manager
+// RunManager starts the actual manager.
 func RunManager() {
-
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -73,8 +72,10 @@ func RunManager() {
 	}
 
 	enableLeaderElection := false
+
 	if _, err := rest.InClusterConfig(); err == nil {
 		klog.Info("LeaderElection enabled as running in a cluster")
+
 		enableLeaderElection = true
 	} else {
 		klog.Info("LeaderElection disabled as not running in a cluster")

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -30,7 +30,7 @@ var options = ControllerRunOptions{
 	ApplicationCRDFile: "/usr/local/etc/application/crds/app.k8s.io_applications.yaml",
 }
 
-// ProcessFlags parses command line parameters into options
+// ProcessFlags parses command line parameters into options.
 func ProcessFlags() {
 	flag := pflag.CommandLine
 

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -1,7 +1,10 @@
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the multicloudlab/tools repo.
-  golangci-lint-version: 1.18.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.25.x # use the fixed version to not introduce new linters unexpectedly
 run:
+  # include test files or not, default is true
+  tests: false
+
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m
   timeout: 20m
@@ -39,9 +42,14 @@ linters:
     - scopelint
     - funlen
     - bodyclose
+    - gomnd
   fast: false
 
 linters-settings:
+  nestif:
+    # minimal complexity of if statements to report, 5 by default
+    min-complexity: 20
+
   errcheck:
     # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
     # default is false: such cases aren't reported by default.

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -7,7 +7,7 @@ import (
 // AddToSchemes may be used to add all resources defined in the project to a Scheme
 var AddToSchemes runtime.SchemeBuilder
 
-// AddToScheme adds all Resources to the Scheme
+// AddToScheme adds all Resources to the Scheme.
 func AddToScheme(s *runtime.Scheme) error {
 	return AddToSchemes.AddToScheme(s)
 }

--- a/pkg/controller/application/application_controller.go
+++ b/pkg/controller/application/application_controller.go
@@ -42,7 +42,7 @@ func Add(mgr manager.Manager) error {
 	return add(mgr, newReconciler(mgr))
 }
 
-// newReconciler returns a new reconcile.Reconciler
+// newReconciler returns a new reconcile.Reconciler.
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	erecorder, _ := utils.NewEventRecorder(mgr.GetConfig(), mgr.GetScheme())
 
@@ -142,7 +142,7 @@ func (mapper *subscriptionMapper) Map(obj handler.MapObject) []reconcile.Request
 	return requests
 }
 
-// add adds a new Controller to mgr with r as the reconcile.Reconciler
+// add adds a new Controller to mgr with r as the reconcile.Reconciler.
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
 	c, err := controller.New("application-controller", mgr, controller.Options{Reconciler: r})

--- a/pkg/controller/application/application_controller_suite_test.go
+++ b/pkg/controller/application/application_controller_suite_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// StartTestManager adds recFn
+// StartTestManager adds recFn.
 func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) (chan struct{}, *sync.WaitGroup) {
 	stop := make(chan struct{})
 

--- a/pkg/controller/application/hub.go
+++ b/pkg/controller/application/hub.go
@@ -64,7 +64,7 @@ func (r *ReconcileApplication) doAppHubReconcile(app *appv1beta1.Application) {
 	app.Annotations["apps.open-cluster-management.io/deployables"] = dplstr
 }
 
-//GetAllSubscriptionDeployablesByApplication get all subscriptions and their deployables.app.ibm.com objects by a application
+//GetAllSubscriptionDeployablesByApplication get all subscriptions and their deployables.app.ibm.com objects by a application.
 func (r *ReconcileApplication) GetAllSubscriptionDeployablesByApplication(app *appv1beta1.Application,
 	allClusterDplMap map[string]*utils.DplMap) ([]*subv1.Subscription, error) {
 	var allSubs []*subv1.Subscription
@@ -140,7 +140,7 @@ func (r *ReconcileApplication) GetAllSubscriptionDeployablesByApplication(app *a
 	return allSubs, nil
 }
 
-//GetAllNewDeployablesByApplication get all deployables.app.ibm.com objects by a application
+//GetAllNewDeployablesByApplication get all deployables.app.ibm.com objects by a application.
 func (r *ReconcileApplication) GetAllNewDeployablesByApplication(
 	app *appv1beta1.Application) ([]*subv1.Subscription, []*dplv1.Deployable, map[string]*utils.DplMap) {
 	var allSubs []*subv1.Subscription
@@ -190,7 +190,7 @@ func (r *ReconcileApplication) GetAllNewDeployablesByApplication(
 	return newAllSubs, newAllDpls, allClusterDplMap
 }
 
-//GetAllApplications get all applications
+//GetAllApplications get all applications.
 func (r *ReconcileApplication) GetAllApplications() ([]appv1beta1.Application, error) {
 	// find everything with label pointer
 	klog.V(1).Infoln("Entering get all Applications")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,7 +7,7 @@ import (
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 var AddToManagerFuncs []func(manager.Manager) error
 
-// AddToManager adds all Controllers to the Manager
+// AddToManager adds all Controllers to the Manager.
 func AddToManager(m manager.Manager) error {
 	for _, f := range AddToManagerFuncs {
 		if err := f(m); err != nil {

--- a/utils/eventlog.go
+++ b/utils/eventlog.go
@@ -38,7 +38,7 @@ const VeryNoisy = 10
 
 var regexStripFnPreamble = regexp.MustCompile(`^.*\.(.*)$`)
 
-// GetFnName - get name of function
+// GetFnName - get name of function.
 func GetFnName() string {
 	fnName := "<unknown>"
 	// Skip this function, and fetch the PC and file for its parent
@@ -50,12 +50,12 @@ func GetFnName() string {
 	return fnName
 }
 
-// EnterFnString - called when enter a function
+// EnterFnString - called when enter a function.
 func EnterFnString() string {
 	return ""
 }
 
-// ExitFuString - called when exiting a function
+// ExitFuString - called when exiting a function.
 func ExitFuString(s string) {}
 
 // EventRecorder - record kubernetes event
@@ -63,7 +63,7 @@ type EventRecorder struct {
 	record.EventRecorder
 }
 
-// NewEventRecorder - create new event recorder from rect config
+// NewEventRecorder - create new event recorder from rect config.
 func NewEventRecorder(cfg *rest.Config, scheme *apiruntime.Scheme) (*EventRecorder, error) {
 	reccs, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
@@ -81,7 +81,7 @@ func NewEventRecorder(cfg *rest.Config, scheme *apiruntime.Scheme) (*EventRecord
 	return rec, nil
 }
 
-// RecordEvent - record kuberentes event
+// RecordEvent - record kuberentes event.
 func (rec *EventRecorder) RecordEvent(obj apiruntime.Object, reason, msg string, err error) {
 	eventType := corev1.EventTypeNormal
 	evnetMsg := msg

--- a/utils/explore.go
+++ b/utils/explore.go
@@ -28,12 +28,12 @@ const (
 	ResourceLabelName = "name"
 )
 
-//DplMap store all dpl names for a cluster [dplName]
+//DplMap store all dpl names for a cluster [dplName].
 type DplMap struct {
 	DplResourceMap map[string]*dplv1alpha1.Deployable
 }
 
-//GetUniqueDeployables get unique deployable array
+//GetUniqueDeployables get unique deployable array.
 func GetUniqueDeployables(allDpls []*dplv1alpha1.Deployable) []*dplv1alpha1.Deployable {
 	dplmap := make(map[string]*dplv1alpha1.Deployable)
 
@@ -50,7 +50,7 @@ func GetUniqueDeployables(allDpls []*dplv1alpha1.Deployable) []*dplv1alpha1.Depl
 	return newdpls
 }
 
-//GetUniqueSubscriptions get unique subscription array
+//GetUniqueSubscriptions get unique subscription array.
 func GetUniqueSubscriptions(allSubs []*subv1alpha1.Subscription) []*subv1alpha1.Subscription {
 	submap := make(map[string]*subv1alpha1.Subscription)
 
@@ -67,7 +67,7 @@ func GetUniqueSubscriptions(allSubs []*subv1alpha1.Subscription) []*subv1alpha1.
 	return newsubs
 }
 
-//PrintAllClusterDplMap print all cluster deployable map
+//PrintAllClusterDplMap print all cluster deployable map.
 func PrintAllClusterDplMap(allClusterDplMap map[string]*DplMap) {
 	for cluster, dplmap := range allClusterDplMap {
 		for dplname, dpl := range dplmap.DplResourceMap {
@@ -86,7 +86,7 @@ func PrintAllClusterDplMap(allClusterDplMap map[string]*DplMap) {
 	}
 }
 
-//AppendClusterDplMap append dpl and its deployed cluster to allClusterDplMap
+//AppendClusterDplMap append dpl and its deployed cluster to allClusterDplMap.
 func AppendClusterDplMap(statusdpl dplv1alpha1.Deployable, dpl dplv1alpha1.Deployable, allClusterDplMap map[string]*DplMap) {
 	if statusdpl.Status.Phase == "Propagated" || statusdpl.Status.Phase == "Deployed" {
 		for cluster := range statusdpl.Status.PropagatedStatus {

--- a/utils/kubernetes.go
+++ b/utils/kubernetes.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/klog"
 )
 
-// ConvertLabels coverts label selector to lables.Selector
+// ConvertLabels coverts label selector to lables.Selector.
 func ConvertLabels(labelSelector *metav1.LabelSelector) (labels.Selector, error) {
 	if labelSelector != nil {
 		selector, err := metav1.LabelSelectorAsSelector(labelSelector)
@@ -46,7 +46,7 @@ func ConvertLabels(labelSelector *metav1.LabelSelector) (labels.Selector, error)
 }
 
 // CheckAndInstallCRD checks if deployable belongs to this cluster
-// managed cluster annotation matches or no managed cluster annotation (local)
+// managed cluster annotation matches or no managed cluster annotation (local).
 func CheckAndInstallCRD(crdconfig *rest.Config, pathname string) error {
 	var err error
 

--- a/utils/kubernetes_suite_test.go
+++ b/utils/kubernetes_suite_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// StartTestManager adds recFn
+// StartTestManager adds recFn.
 func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) (chan struct{}, *sync.WaitGroup) {
 	stop := make(chan struct{})
 

--- a/webhook/certificate.go
+++ b/webhook/certificate.go
@@ -143,7 +143,7 @@ func getSignedCert(clt client.Client, whKey types.NamespacedName,
 }
 
 // GenerateWebhookCerts generate self singed CA and a signed cert pair. The
-// signed pair is stored at the certDir
+// signed pair is stored at the certDir.
 func GenerateWebhookCerts(clt client.Client, certDir string) ([]byte, error) {
 	if len(certDir) == 0 {
 		certDir = filepath.Join(os.TempDir(), "k8s-webhook-server", "application-serving-certs")
@@ -187,7 +187,7 @@ func GenerateWebhookCerts(clt client.Client, certDir string) ([]byte, error) {
 	return []byte(ca.Cert), nil
 }
 
-// GenerateSelfSignedCACert generates a self signed CA
+// GenerateSelfSignedCACert generates a self signed CA.
 func GenerateSelfSignedCACert(cn string) (Certificate, error) {
 	ca := Certificate{}
 
@@ -211,7 +211,7 @@ func GenerateSelfSignedCACert(cn string) (Certificate, error) {
 	return ca, err
 }
 
-// GenerateSignedCert generated cert pair which is signed by the self signed CA
+// GenerateSignedCert generated cert pair which is signed by the self signed CA.
 func GenerateSignedCert(cn string, alternateDNS []string, ca Certificate) (Certificate, error) {
 	cert := Certificate{}
 

--- a/webhook/wireupwebhook.go
+++ b/webhook/wireupwebhook.go
@@ -72,7 +72,7 @@ func WireUpWebhook(clt client.Client, mgr manager.Manager, whk *webhook.Server, 
 }
 
 //assuming we have a service set up for the webhook, and the service is linking
-//to a secret which has the CA
+//to a secret which has the CA.
 func WireUpWebhookSupplymentryResource(mgr manager.Manager, stop <-chan struct{}, wbhSvcName, validatorName, certDir string, caCert []byte) {
 	log.Info("entry wire up webhook")
 	defer log.Info("exit wire up webhook ")


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Lint has been silently failing for this repo for a while now so there are tons of fixes that are needed.

without introducing the risk of a unnecessary regression, I have modified the lint config to have
- `min-complexity: 20`
- disabled `gomnd` which checks for magic number (ie: it complains about the `5` in `klog.V(5).Info`)

In retrospective, I probably should've disabled the period check at the end of the comment too to save time. I will most likely do that in the other repos, if you are ok with this XJ. Thanks.