### PR TITLE
remove travis sonar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ jobs:
         - |
           make
           make component/test/unit
-          make sonar/go
     - stage: test-e2e
       name: "Deploy the image to a cluster and run e2e tests"
       if: type = pull_request

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -27,7 +27,7 @@ build:
 lint:
 	@build/run-code-lint.sh
 
-.PHONY: unit-test
+.PHONY: test
 
-unit-test:
+test:
 	@build/run-unit-tests.sh


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

sonar scan is now being don in prow and it causes a conflict if its done on travis as well

merging for now please comment if you disagree with the changes here.