### PR TITLE
remove codecov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ else
     $(error "This system's OS $(LOCAL_OS) isn't recognized/supported")
 endif
 
-.PHONY: fmt lint test coverage build build-images
+.PHONY: fmt lint test build build-images
 
 # GITHUB_USER containing '@' char must be escaped with '%40'
 GITHUB_USER := $(shell echo $(GITHUB_USER) | sed 's/@/%40/g')
@@ -112,8 +112,6 @@ test:
 # coverage section
 ############################################################
 
-coverage:
-	@common/scripts/codecov.sh
 
 ############################################################
 # build section


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

open-cluster-management/backlog#11935

remove codecov as we don't use it to get code test coverage any more. And codecov has CVE reported

there is no codecov.sh in the repo, just modifed the Makefile