### PR TITLE
fix application webhook nil decoder error

### DIFF
--- a/webhook/application_validator.go
+++ b/webhook/application_validator.go
@@ -65,12 +65,3 @@ func (v *AppValidator) Handle(_ context.Context, req admission.Request) admissio
 
 	return admission.Allowed("")
 }
-
-// AppValidator implements admission.DecoderInjector.
-// A decoder will be automatically injected.
-
-// InjectDecoder injects the decoder.
-func (v *AppValidator) InjectDecoder(d admission.Decoder) error {
-	v.decoder = d
-	return nil
-}

--- a/webhook/wireupwebhook.go
+++ b/webhook/wireupwebhook.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	appv1beta1 "sigs.k8s.io/application/api/v1beta1"
 )
@@ -63,10 +64,10 @@ func WireUpWebhook(clt client.Client, mgr manager.Manager, whk webhook.Server, c
 	klog.Info("registering webhooks to the webhook server")
 
 	appValidator := &AppValidator{
-		Client: mgr.GetClient(),
+		Client:  mgr.GetClient(),
+		decoder: admission.NewDecoder(mgr.GetScheme()),
 	}
 
-	// The decoder will be injected by the webhook server
 	whk.Register(ValidatorPath, &webhook.Admission{
 		Handler: appValidator,
 	})


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ACM-32482

The AppValidator.decoder field was nil at runtime. The code relied on the old InjectDecoder pattern to have controller-runtime automatically inject the decoder. However, controller-runtime v0.21.0 removed this automatic injection, so InjectDecoder was never called and decoder stayed nil
