### PR TITLE
Refactor Makefile to use setup-envtest for envtest binaries

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -35,13 +35,10 @@ BASE_DIR := $(shell basename $(PWD))
 # Controller runtime need use this variable as tmp cache dir. if not set, ut will fail in prow
 export XDG_CACHE_HOME ?= $(BASE_DIR)/.cache
 
-TEST_TMP :=/tmp
-export KUBEBUILDER_ASSETS ?=$(TEST_TMP)/kubebuilder/bin
-K8S_VERSION ?=1.19.2
-GOHOSTOS ?=$(shell go env GOHOSTOS)
-GOHOSTARCH ?= $(shell go env GOHOSTARCH)
-KB_TOOLS_ARCHIVE_NAME :=kubebuilder-tools-$(K8S_VERSION)-$(GOHOSTOS)-$(GOHOSTARCH).tar.gz
-KB_TOOLS_ARCHIVE_PATH := $(TEST_TMP)/$(KB_TOOLS_ARCHIVE_NAME)
+# Use setup-envtest to download envtest binaries from the new location (controller-tools releases).
+# See: https://github.com/kubernetes-sigs/kubebuilder/discussions/4082
+ENVTEST_K8S_VERSION ?= 1.30.0
+ENVTEST_VERSION ?= v0.20.4
 
 .PHONY: build
 
@@ -71,18 +68,11 @@ lint-go:
 
 .PHONY: ensure-kubebuilder-tools
 
-# download the kubebuilder-tools to get kube-apiserver binaries from it
+# Install setup-envtest (used to download envtest binaries from controller-tools GitHub releases).
 ensure-kubebuilder-tools:
-ifeq "" "$(wildcard $(KUBEBUILDER_ASSETS))"
-	$(info Downloading kube-apiserver into '$(KUBEBUILDER_ASSETS)')
-	mkdir -p '$(KUBEBUILDER_ASSETS)'
-	curl -s -f -L https://storage.googleapis.com/kubebuilder-tools/$(KB_TOOLS_ARCHIVE_NAME) -o '$(KB_TOOLS_ARCHIVE_PATH)'
-	tar -C '$(KUBEBUILDER_ASSETS)' --strip-components=2 -zvxf '$(KB_TOOLS_ARCHIVE_PATH)'
-else
-	$(info Using existing kube-apiserver from "$(KUBEBUILDER_ASSETS)")
-endif
+	@which setup-envtest >/dev/null 2>&1 || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: test
 
 test: ensure-kubebuilder-tools
-	go test -timeout 300s -v ./pkg/...
+	KUBEBUILDER_ASSETS=$$(setup-envtest use -i -p path $(ENVTEST_K8S_VERSION)) go test -timeout 300s -v ./pkg/... -coverprofile=coverage.out


### PR DESCRIPTION
Updated Makefile to use setup-envtest for downloading envtest binaries and removed old kubebuilder-tools download logic.