### PR TITLE
ACM-37684: Bump Go to 1.26 to address CVE-2026-27145

### DIFF
--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-application
 COPY . .

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plugin-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS plugin-builder
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-application
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicloud-operators-application
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32


### PR DESCRIPTION
## Summary

Bump Go builder images from 1.25 to 1.26 to address CVE-2026-27145 (crypto/x509 DoS).

## Changes

- `go.mod`: `go 1.25.0` → `go 1.26.0`
- `build/Dockerfile.prow`: stolostron builder `go1.25-linux` → `go1.26-linux`
- `build/Dockerfile.rhtap`: brew builder `rhel_9_1.25` → `rhel_9_1.26`

## Reference

- Main branch PR: https://github.com/stolostron/multicloud-operators-application/pull/375

Made with [Cursor](https://cursor.com)