### PR TITLE
Disable lint-go and add falconizmi to OWNERS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,15 @@ check: lint
 #    eg: lint: lint-go lint-yaml
 lint: lint-all
 
+.PHONY: lint-all
+
+lint-all:lint-go
+
+.PHONY: lint-go
+
+lint-go:
+	@true
+
 ############################################################
 # test section
 ############################################################

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -64,8 +64,7 @@ lint-yaml:
 .PHONY: lint-go
 
 lint-go:
-	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | ${XARGS} common/scripts/lint_go.sh
-
+	@true
 .PHONY: ensure-kubebuilder-tools
 
 # Install setup-envtest (used to download envtest binaries from controller-tools GitHub releases).

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -74,4 +74,5 @@ ensure-kubebuilder-tools:
 .PHONY: test
 
 test: ensure-kubebuilder-tools
+	go clean -cache
 	KUBEBUILDER_ASSETS=$$(setup-envtest use -i -p path $(ENVTEST_K8S_VERSION)) go test -timeout 300s -v ./pkg/... -coverprofile=coverage.out

--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ approvers:
 - philipwu08
 - rokej
 - xiangjingli
+- falconizmi
 - chenz4027
 - lennysgarage
 reviewers:


### PR DESCRIPTION
Disable lint-go in Makefile.prow and Makefile for Go 1.26 compatibility. Add falconizmi to OWNERS approvers.